### PR TITLE
Patch Git URLs

### DIFF
--- a/gitchglog.go
+++ b/gitchglog.go
@@ -30,7 +30,8 @@ func addMissingChgLogConfig(conf, gitUrl string) error {
 		return fmt.Errorf("clould not make dir %q", confDir)
 	}
 
-	outStr := strings.Replace(gitChgLogConf, "${VCS_URL}", "'"+gitUrl+"'", 1)
+	url := convertGitToHttp(gitUrl)
+	outStr := strings.Replace(gitChgLogConf, "${VCS_URL}", "'"+url+"'", 1)
 
 	if e := ioutil.WriteFile(conf, []byte(outStr), dirMode); e != nil {
 		return e
@@ -48,4 +49,13 @@ func addMissingChgLogConfig(conf, gitUrl string) error {
 	infof("found git-chglog config here %q\n", conf)
 
 	return nil
+}
+
+func convertGitToHttp(url string) string {
+
+	if strings.HasPrefix(url, "git@") {
+		url = strings.Replace(url, ":", "/", 1)
+		url = strings.Replace(url, "git@", "https://", 1)
+	}
+	return url
 }

--- a/gitchglog_test.go
+++ b/gitchglog_test.go
@@ -29,3 +29,24 @@ func TestAddMissingChgLogConfig(tester *testing.T) {
 		})
 	}
 }
+
+func TestConvertGitToHttp(tester *testing.T) {
+	var testCases = []struct {
+		name   string
+		gitUrl string
+		want   string
+	}{
+		{"noConf", "git@github.com/example/app.git", "https://github.com/example/app.git"},
+		{"noConfHttps", "https://github.com/example/app", "https://github.com/example/app"},
+	}
+
+	for _, tc := range testCases {
+		tester.Run(tc.name, func(t *testing.T) {
+			got := convertGitToHttp(tc.gitUrl)
+
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a new Git-ChgLog config needs to be added to a project the URL may
not be in HTTP format but SSH. So convert it to an HTTP URL.