### PR TITLE
Continuous Integration: Fixed workflow-seletor Loop Bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
         description: SSH fingerprint.
         type: string
     triggered_flow:
-        default: ""
+        default: "workflow-selector"
         description: Indicates with workflow should run.
         type: string
 
@@ -108,6 +108,7 @@ workflows:
     workflow-selector:
         when:
             and:
+                - equal: ["workflow-selector", << pipeline.parameters.triggered_flow >>]
                 - equal: [main, << pipeline.git.branch >>]
         jobs:
             - vro/workflow-selector:


### PR DESCRIPTION
The workflow was constantly triggering itself as it triggered pipelines against the main trunk but did not check the triggered_flow parameter to exclude triggering itself.