### PR TITLE
Continuous Integration: Publish Release Flow With Bad Parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ workflows:
     publish-release-tag:
         when:
             and:
-                - equal: ["tag-and-release", << pipeline.parameters.triggered_flow >>]
+                - equal: ["publish-release-tag", << pipeline.parameters.triggered_flow >>]
         jobs:
             - run-test:
                 context: << pipeline.parameters.ctx_docker >>


### PR DESCRIPTION
Fixed the value of the publish-release-tag filter to allow proper triggering.